### PR TITLE
blueprint interface changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 libc = "0.2.94"
 goblin = "0.4.0"
 nix = "0.20.0"
+itertools = "0.10.0"
 
 [dev-dependencies]
 memmap = "0.7.0"

--- a/src/bpf/mod.rs
+++ b/src/bpf/mod.rs
@@ -189,3 +189,17 @@ impl From<ProgramType> for u32 {
         }
     }
 }
+
+impl From<&str> for ProgramType {
+    fn from(value: &str) -> ProgramType {
+        match value {
+            "kprobe" => ProgramType::Kprobe,
+            "kretprobe" => ProgramType::Kretprobe,
+            "uprobe" => ProgramType::Uprobe,
+            "uretprobe" => ProgramType::Uretprobe,
+            "tracepoint" => ProgramType::Tracepoint,
+            "rawtracepoint" => ProgramType::RawTracepoint,
+            _ => ProgramType::Unspec,
+        }
+    }
+}


### PR DESCRIPTION
Split out objects to be `maps` and `programs` for easier access. The `maps` key is the symbol name of the map, while the `programs` key is the section name of the map, if one is present.