### PR TITLE
remove `kind` from the constructor and make it an optional specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,11 @@ let mut program_group = ProgramGroup::new(
     program_blueprint,
     vec![ProgramVersion::new(vec![
         Program::new(
-            ProgramType::Kprobe,
             "test_program_map_update",
             vec!["do_mount"],
         )
         .syscall(true),
-        Program::new(ProgramType::Kprobe, "test_program", vec!["do_mount"]).syscall(true),
+        Program::new("test_program", vec!["do_mount"]).syscall(true),
     ])],
     None,
 );


### PR DESCRIPTION
This allows the user to optionally specify the kind of program they want to load. If nothing is specified, it will default to whatever the ELF file says to use. If something is specified, it will attempt to load the program as the specified type (even if loading and attaching as such will fail or error). This will allow a user to, for example, load the same generic kprobe twice: once as a kprobe and once as a retprobe. Or, once TC support is added, load the same classifier for ingress and egress.