### PR TITLE
provide `ProgramVersion` vec and `ProgramBlueprint` upon load

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ use std::{
     format,
     io::{BufRead, BufReader, BufWriter, Write},
     os::unix::io::RawFd,
+    thread,
     time::Duration,
 };
 
@@ -127,6 +128,7 @@ pub struct ProgramVersion<'a> {
     has_perf_maps: bool,
     mem_limit: Option<usize>,
     original_limit: usize,
+    polling_delay: u64,
 }
 
 impl<'a> Clone for ProgramVersion<'a> {
@@ -144,6 +146,7 @@ impl<'a> Clone for ProgramVersion<'a> {
                 .iter()
                 .map(|fd| unsafe { libc::fcntl(*fd, libc::F_DUPFD_CLOEXEC, 3) })
                 .collect(),
+            polling_delay: self.polling_delay,
         }
     }
 }
@@ -641,11 +644,19 @@ impl ProgramVersion<'_> {
             has_perf_maps: false,
             mem_limit: None,
             original_limit: get_memlock_limit().unwrap_or(libc::RLIM_INFINITY as usize),
+            polling_delay: 100,
         }
     }
 
+    /// Manually set the memlock ulimit for this `ProgramVersion`.
     pub fn mem_limit(mut self, limit: usize) -> Self {
         self.mem_limit = Some(limit);
+        self
+    }
+
+    /// Manually specify the perfmap polling interval for this `ProgramVersion`.
+    pub fn polling_delay(mut self, delay: u64) -> Self {
+        self.polling_delay = delay;
         self
     }
 
@@ -653,6 +664,7 @@ impl ProgramVersion<'_> {
         &self,
         perfmaps: Vec<PerfMap>,
         tx: Sender<PerfChannelMessage>,
+        polling_delay: u64,
     ) -> Result<(), OxidebpfError> {
         let result = std::thread::Builder::new()
             .name("PerfMapPoller".to_string())
@@ -746,6 +758,7 @@ impl ProgramVersion<'_> {
 
                         processed += 1;
                     }
+                    thread::sleep(Duration::from_millis(polling_delay));
                 }
             });
 
@@ -992,7 +1005,7 @@ impl ProgramVersion<'_> {
         // start event poller and pass back channel, if one exists
         if !perfmaps.is_empty() {
             self.has_perf_maps = true;
-            self.event_poller(perfmaps, channel.tx)?;
+            self.event_poller(perfmaps, channel.tx, self.polling_delay)?;
         }
         Ok(())
     }

--- a/src/maps.rs
+++ b/src/maps.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use std::os::raw::{c_long, c_uchar, c_uint, c_ulong, c_ushort};
 use std::os::unix::io::RawFd;
 use std::ptr::null_mut;
@@ -79,7 +80,7 @@ pub(crate) fn get_cpus() -> Result<Vec<i32>, OxidebpfError> {
 }
 
 pub(crate) enum PerfEvent<'a> {
-    Sample(Box<PerfEventSample>),
+    Sample(PerfEventSample),
     Lost(&'a PerfEventLostSamples),
 }
 
@@ -341,7 +342,7 @@ impl PerfMap {
 
         unsafe {
             if end < start {
-                let len = (raw_size as usize - start) as usize;
+                let len = raw_size as usize - start;
                 let ptr = base.add(start);
                 buf.extend_from_slice(slice::from_raw_parts(ptr, len));
 
@@ -359,23 +360,37 @@ impl PerfMap {
 
             match (*event).type_ {
                 perf_event_type::PERF_RECORD_SAMPLE => {
-                    let header_bytes: Vec<u8> = buf
-                        .drain(..std::mem::size_of::<PerfEventHeader>())
-                        .collect();
-                    let len: Vec<u8> = buf.drain(..std::mem::size_of::<u32>()).collect();
-                    let data: Vec<u8> = buf.drain(..).collect();
-                    let (_, header, _) = header_bytes.align_to::<PerfEventHeader>();
-                    let (_, size, _) = len.align_to::<u32>();
-                    if header.len() != 1 {
-                        return Err(OxidebpfError::BadPerfSample);
-                    }
-                    if size.len() != 1 {
-                        return Err(OxidebpfError::BadPerfSample);
-                    }
-                    let header = *header.get(0).ok_or(OxidebpfError::BadPerfSample)?;
-                    let size = *size.get(0).ok_or(OxidebpfError::BadPerfSample)?;
-                    let sample = Box::new(PerfEventSample { header, size, data });
-                    Ok(Some(PerfEvent::<'a>::Sample(sample)))
+                    use std::mem::size_of;
+
+                    let header = {
+                        let header_bytes: [u8; size_of::<PerfEventHeader>()] = buf
+                            [..size_of::<PerfEventHeader>()]
+                            .try_into()
+                            .map_err(|_| OxidebpfError::BadPerfSample)?;
+                        std::ptr::read(header_bytes.as_ptr() as *const _)
+                    };
+
+                    let size = {
+                        let size_bytes: [u8; size_of::<u32>()] = buf[size_of::<PerfEventHeader>()
+                            ..(size_of::<u32>() + size_of::<PerfEventHeader>())]
+                            .try_into()
+                            .map_err(|_| OxidebpfError::BadPerfSample)?;
+                        u32::from_ne_bytes(size_bytes)
+                    };
+
+                    let data = {
+                        // drain the header + len fields; the rest is the data
+                        buf.drain(
+                            ..(std::mem::size_of::<PerfEventHeader>() + std::mem::size_of::<u32>()),
+                        )
+                        // might be unnecesary but I like this being explicit
+                        .for_each(|_| {});
+
+                        buf
+                    };
+
+                    let sample = PerfEventSample { header, size, data };
+                    Ok(Some(PerfEvent::Sample(sample)))
                 }
                 perf_event_type::PERF_RECORD_LOST => Ok(Some(PerfEvent::<'a>::Lost(
                     &*(buf.as_ptr() as *const PerfEventLostSamples),


### PR DESCRIPTION
From RND-52, we're storing all the `ProgramVersion`s only to load one and then dump the rest. This changes is so that the `ProgramVersion`s and `ProgramBlueprint` can be provided when you load a `ProgramGroup`, instead of when calling `new()`. 