### PR TITLE
additional logging

### DIFF
--- a/src/perf/mod.rs
+++ b/src/perf/mod.rs
@@ -137,3 +137,18 @@ impl Default for PerfEventAttr {
         }
     }
 }
+
+#[repr(C)]
+#[derive(Debug, Default)]
+struct CapUserHeader {
+    version: u32,
+    pid: i32,
+}
+
+#[repr(C)]
+#[derive(Debug, Default)]
+struct CapUserData {
+    effective: u32,
+    permitted: u32,
+    inheritable: u32,
+}

--- a/src/perf/syscall.rs
+++ b/src/perf/syscall.rs
@@ -12,6 +12,7 @@ use nix::{ioctl_none, ioctl_write_int};
 
 use crate::error::OxidebpfError;
 use crate::perf::constant::perf_flag::PERF_FLAG_FD_CLOEXEC;
+use crate::perf::{CapUserData, CapUserHeader};
 
 // the compiler doesn't recognize that these _are_ used
 #[allow(unused_imports)]
@@ -220,6 +221,28 @@ pub(crate) fn perf_event_open(
             LOGGER.0,
             "perf_event_open(); error while calling SYS_perf_event_open; errno: {}", e
         );
+
+        // check if the kernel is too paranoid
+        let perf_paranoid_setting =
+            std::fs::read_to_string((*PERF_PATH).as_path()).unwrap_or_else(|e| e.to_string());
+        info!(
+            LOGGER.0,
+            "Perf paranoid settings: {}", perf_paranoid_setting
+        );
+
+        // check if we're missing capabilities
+        let mut hdrp = CapUserHeader::default();
+        let mut datap = CapUserData::default();
+
+        let ret =
+            unsafe { libc::syscall(libc::SYS_capset, &mut hdrp as *mut _, &mut datap as *mut _) };
+
+        if ret < 0 {
+            info!(LOGGER.0, "could not read capabilities")
+        } else {
+            info!(LOGGER.0, "CapHeader: {:?}; CapData: {:?}", hdrp, datap);
+        }
+
         return Err(OxidebpfError::LinuxError(
             format!(
                 "perf_event_open(0x{:x} [{:?}], {}, {}, {}, {})",


### PR DESCRIPTION
This will log the entire `attr` in `perf_event_open`, as well as gather the current capability set and perf paranoid settings when the call fails.