### PR TITLE
remove unnecessary comment

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,4 @@
 ARCH ?= x86_64
-# in the docker image, CC may be set to cc but we need clang
 CC ?= clang-6.0
 LLC ?= llc-6.0
 OPT ?= opt-6.0


### PR DESCRIPTION
Follow-up on https://github.com/redcanaryco/oxidebpf/pull/38 - the comment about CC being cc is not needed with the current approach.