### PR TITLE
fix kretprobe debugfs attaching

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -49,6 +49,10 @@ pub enum OxidebpfError {
     ProgramGroupAlreadyLoaded,
     RetryError(String),
     LockError,
+    /// This error is returned when trying to attach a kretprobe with debugfs.
+    /// There's a chance we need to change the path name and retry, which is what
+    /// this error indicates.
+    KretprobeNamingError,
 }
 
 impl Display for OxidebpfError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,6 +452,7 @@ impl<'a> Program<'a> {
                         }
                     }
                     Err(e) => {
+                        info!(LOGGER.0, "Program::attach_kprobe(); original error: {:?}", e);
                         self.mount_debugfs_if_missing();
                         match attach_kprobe_debugfs(self.fd, attach_point, is_return, None, 0) {
                             Ok((path, fd)) => {


### PR DESCRIPTION
When attaching a retprobe tracepoint with debugfs, we may need to use either `kprobe` or `kretprobe` in the path name. Previously, we were try-catching loading errors and attempting a new name. Now we explicitly return an error for kretprobes which denotes that we should retry.