### PR TITLE
Fix default num cpus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "A pure-Rust library for managing eBPF programs."
 homepage = "https://github.com/redcanaryco/oxidebpf"
 repository = "https://github.com/redcanaryco/oxidebpf"
 readme = "README.md"
-version = "0.1.2"
+version = "0.1.3"
 license = "BSD-3-Clause"
 keywords = ["eBPF", "BPF", "linux"]
 categories = ["config", "data-structures", "os::linux-apis", "parsing"]
@@ -14,6 +14,7 @@ authors = [
     "Rafael Ortiz <rafael.ortiz@redcanary.com>",
     "Dave Bogle <dave.bogle@redcanary.com>",
     "Andrés Medina <andres.medina@redcanary.com>",
+    "Vince Bundage <vince.bundage@redcanary.com>"
 ]
 edition = "2021"
 

--- a/src/cpu_info.rs
+++ b/src/cpu_info.rs
@@ -37,16 +37,19 @@ pub fn max_possible_index() -> Result<usize, OxidebpfError> {
 }
 
 fn max_index(cpu_string: &str) -> Result<usize, OxidebpfError> {
-    let last = cpu_string.split(',').last().ok_or(OxidebpfError::CpuOnlineFormatError)?;
+    let last = cpu_string
+        .split(',')
+        .last()
+        .ok_or(OxidebpfError::CpuOnlineFormatError)?;
 
     let last_index = match last.split_once('-') {
         None => last,
-        Some((_, b)) => b
+        Some((_, b)) => b,
     };
 
-    last_index.parse().map_err(|_| {
-        OxidebpfError::CpuOnlineFormatError
-    })
+    last_index
+        .parse()
+        .map_err(|_| OxidebpfError::CpuOnlineFormatError)
 }
 
 fn process_cpu_string(cpu_string: String) -> Result<Vec<i32>, OxidebpfError> {

--- a/src/cpu_info.rs
+++ b/src/cpu_info.rs
@@ -30,6 +30,7 @@ pub fn max_possible_index() -> Result<usize, OxidebpfError> {
 
 fn max_index(cpu_string: &str) -> Result<usize, OxidebpfError> {
     let last = cpu_string
+        .trim()
         .split(',')
         .last()
         .ok_or(OxidebpfError::CpuOnlineFormatError)?;
@@ -111,7 +112,7 @@ mod tests {
 
     #[test]
     fn combination() {
-        let result = max_index("0,3-5,8").expect("did not parse cpu_string");
+        let result = max_index("0,3-5,8\n").expect("did not parse cpu_string");
         assert_eq!(result, 8);
     }
 

--- a/src/cpu_info.rs
+++ b/src/cpu_info.rs
@@ -6,7 +6,7 @@ pub fn online() -> Result<Vec<i32>, OxidebpfError> {
     let cpu_string = std::fs::read_to_string("/sys/devices/system/cpu/online").map_err(|e| {
         info!(
             LOGGER.0,
-            "get_cpus(); could not read /sys/devices/system/cpu/online; error: {:?}", e
+            "cpu_info::online(); could not read /sys/devices/system/cpu/online; error: {:?}", e
         );
         OxidebpfError::FileIOError
     })?;
@@ -19,7 +19,7 @@ pub fn max_possible_index() -> Result<usize, OxidebpfError> {
         |e| {
             info!(
                 LOGGER.0,
-                "get_possible_cpu_count(); could not read /sys/devices/system/cpu/possible; error: {:?}", e
+                "cpu_info::max_possible_index(); could not read /sys/devices/system/cpu/possible; error: {:?}", e
             );
             OxidebpfError::FileIOError
         },

--- a/src/cpu_info.rs
+++ b/src/cpu_info.rs
@@ -1,0 +1,86 @@
+use slog::info;
+
+use crate::{OxidebpfError, LOGGER};
+
+pub fn online() -> Result<Vec<i32>, OxidebpfError> {
+    let cpu_string = String::from_utf8(std::fs::read("/sys/devices/system/cpu/online").map_err(
+        |e| {
+            info!(
+                LOGGER.0,
+                "get_cpus(); could not read /sys/devices/system/cpu/online; error: {:?}", e
+            );
+            OxidebpfError::FileIOError
+        },
+    )?)
+    .map_err(|e| {
+        info!(
+            LOGGER.0,
+            "get_cpus(); utf8 string conversion error while getting cpus; error: {:?}", e
+        );
+        OxidebpfError::Utf8StringConversionError
+    })?;
+    process_cpu_string(cpu_string)
+}
+
+pub fn possible_count() -> Result<usize, OxidebpfError> {
+    let cpu_string = std::fs::read_to_string("/sys/devices/system/cpu/possible").map_err(
+        |e| {
+            info!(
+                LOGGER.0,
+                "get_possible_cpu_count(); could not read /sys/devices/system/cpu/possible; error: {:?}", e
+            );
+            OxidebpfError::FileIOError
+        },
+    )?;
+
+    todo!()
+}
+
+fn process_cpu_string(cpu_string: String) -> Result<Vec<i32>, OxidebpfError> {
+    let mut cpus = vec![];
+
+    for sublist in cpu_string.trim().split(',') {
+        if sublist.contains('-') {
+            let pair: Vec<&str> = sublist.split('-').collect();
+            if pair.len() != 2 {
+                info!(
+                    LOGGER.0,
+                    "process_cpu_string(); cpu online formatting error: {}", cpu_string
+                );
+                return Err(OxidebpfError::CpuOnlineFormatError);
+            }
+
+            // we checked the length above so indexing is OK
+            let from: i32 = pair[0].parse().map_err(|e| {
+                info!(
+                    LOGGER.0,
+                    "process_cpu_string(); cpu online i32 parse error; pair: {:?}; error: {:?}",
+                    pair,
+                    e
+                );
+                OxidebpfError::CpuOnlineFormatError
+            })?;
+            let to: i32 = pair[1].parse().map_err(|e| {
+                info!(
+                    LOGGER.0,
+                    "process_cpu_string(); cpu online i32 parse error; pair: {:?}; error: {:?}",
+                    pair,
+                    e
+                );
+                OxidebpfError::CpuOnlineFormatError
+            })?;
+
+            cpus.extend(from..=to)
+        } else {
+            cpus.push(sublist.trim().parse().map_err(|e| {
+                info!(
+                    LOGGER.0,
+                    "process_cpu_string(); sublist number parsing error; sublist: {:?}; error: {:?}", sublist, e
+                );
+                OxidebpfError::NumberParserError
+            })?);
+        }
+    }
+
+    Ok(cpus)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -810,6 +810,11 @@ impl ProgramVersion<'_> {
         let mut tailcall_tables = HashMap::new();
 
         let mut perfmap_opts = None;
+
+        #[cfg(any(test, doctest))]
+        let perfmap_entries = 1;
+
+        #[cfg(not(any(test, doctest)))]
         let perfmap_entries = cpu_info::max_possible_index()? as u32 + 1;
 
         for program_object in matching_blueprints.iter_mut() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,12 @@
 
 mod blueprint;
 mod bpf;
+mod cpu_info;
 mod debugfs;
 mod error;
 mod maps;
 mod perf;
 mod program_group;
-mod cpu_info;
 
 pub use blueprint::{ProgramBlueprint, SectionType};
 pub use error::OxidebpfError;
@@ -830,7 +830,8 @@ impl ProgramVersion<'_> {
                     match map.definition.map_type {
                         bpf_map_type::BPF_MAP_TYPE_PERF_EVENT_ARRAY => {
                             if map.definition.max_entries == 0 {
-                                map.definition.max_entries = cpu_info::max_possible_index()? as u32 + 1;
+                                map.definition.max_entries =
+                                    cpu_info::max_possible_index()? as u32 + 1;
                             };
 
                             let fd = unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -810,6 +810,7 @@ impl ProgramVersion<'_> {
         let mut tailcall_tables = HashMap::new();
 
         let mut perfmap_opts = None;
+        let perfmap_entries = cpu_info::max_possible_index()? as u32 + 1;
 
         for program_object in matching_blueprints.iter_mut() {
             for name in program_object.required_maps().iter() {
@@ -830,8 +831,7 @@ impl ProgramVersion<'_> {
                     match map.definition.map_type {
                         bpf_map_type::BPF_MAP_TYPE_PERF_EVENT_ARRAY => {
                             if map.definition.max_entries == 0 {
-                                map.definition.max_entries =
-                                    cpu_info::max_possible_index()? as u32 + 1;
+                                map.definition.max_entries = perfmap_entries
                             };
 
                             let fd = unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -830,7 +830,7 @@ impl ProgramVersion<'_> {
                     match map.definition.map_type {
                         bpf_map_type::BPF_MAP_TYPE_PERF_EVENT_ARRAY => {
                             if map.definition.max_entries == 0 {
-                                map.definition.max_entries = cpu_info::possible_count()? as u32;
+                                map.definition.max_entries = cpu_info::max_possible_index()? as u32 + 1;
                             };
 
                             let fd = unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -811,10 +811,6 @@ impl ProgramVersion<'_> {
 
         let mut perfmap_opts = None;
 
-        #[cfg(any(test, doctest))]
-        let perfmap_entries = 1;
-
-        #[cfg(not(any(test, doctest)))]
         let perfmap_entries = cpu_info::max_possible_index()? as u32 + 1;
 
         for program_object in matching_blueprints.iter_mut() {

--- a/src/maps/mod.rs
+++ b/src/maps/mod.rs
@@ -887,7 +887,6 @@ fn lte_power_of_two(n: usize) -> usize {
 #[cfg(test)]
 mod map_tests {
     use crate::error::OxidebpfError;
-    use crate::maps::process_cpu_string;
     use crate::maps::RWMap;
     use crate::maps::{ArrayMap, BpfHashMap};
     use nix::errno::Errno;
@@ -899,19 +898,6 @@ mod map_tests {
             .duration_since(std::time::UNIX_EPOCH)
             .expect("All time is broken!!");
         seed_time.as_millis() as u64
-    }
-
-    #[test]
-    fn test_cpu_formatter() {
-        assert_eq!(vec![0], process_cpu_string("0".to_string()).unwrap());
-        assert_eq!(
-            vec![0, 1, 2],
-            process_cpu_string("0-2".to_string()).unwrap()
-        );
-        assert_eq!(
-            vec![0, 3, 4, 5, 8],
-            process_cpu_string("0,3-5,8".to_string()).unwrap()
-        );
     }
 
     // Test the normal behavior of the array map type

--- a/src/maps/mod.rs
+++ b/src/maps/mod.rs
@@ -22,7 +22,7 @@ use crate::perf::PerfEventAttr;
 use slog::info;
 use std::fmt::{Debug, Display, Formatter};
 
-use crate::{LOGGER, cpu_info};
+use crate::{cpu_info, LOGGER};
 
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/src/maps/mod.rs
+++ b/src/maps/mod.rs
@@ -22,7 +22,7 @@ use crate::perf::PerfEventAttr;
 use slog::info;
 use std::fmt::{Debug, Display, Formatter};
 
-use crate::LOGGER;
+use crate::{LOGGER, cpu_info};
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -43,75 +43,6 @@ pub struct PerfEventSample {
     header: PerfEventHeader,
     pub size: u32,
     pub data: Vec<u8>,
-}
-
-pub(crate) fn process_cpu_string(cpu_string: String) -> Result<Vec<i32>, OxidebpfError> {
-    let mut cpus = vec![];
-
-    for sublist in cpu_string.trim().split(',') {
-        if sublist.contains('-') {
-            let pair: Vec<&str> = sublist.split('-').collect();
-            if pair.len() != 2 {
-                info!(
-                    LOGGER.0,
-                    "process_cpu_string(); cpu online formatting error: {}", cpu_string
-                );
-                return Err(OxidebpfError::CpuOnlineFormatError);
-            }
-
-            // we checked the length above so indexing is OK
-            let from: i32 = pair[0].parse().map_err(|e| {
-                info!(
-                    LOGGER.0,
-                    "process_cpu_string(); cpu online i32 parse error; pair: {:?}; error: {:?}",
-                    pair,
-                    e
-                );
-                OxidebpfError::CpuOnlineFormatError
-            })?;
-            let to: i32 = pair[1].parse().map_err(|e| {
-                info!(
-                    LOGGER.0,
-                    "process_cpu_string(); cpu online i32 parse error; pair: {:?}; error: {:?}",
-                    pair,
-                    e
-                );
-                OxidebpfError::CpuOnlineFormatError
-            })?;
-
-            cpus.extend(from..=to)
-        } else {
-            cpus.push(sublist.trim().parse().map_err(|e| {
-                info!(
-                    LOGGER.0,
-                    "process_cpu_string(); sublist number parsing error; sublist: {:?}; error: {:?}", sublist, e
-                );
-                OxidebpfError::NumberParserError
-            })?);
-        }
-    }
-
-    Ok(cpus)
-}
-
-pub(crate) fn get_cpus() -> Result<Vec<i32>, OxidebpfError> {
-    let cpu_string = String::from_utf8(std::fs::read("/sys/devices/system/cpu/online").map_err(
-        |e| {
-            info!(
-                LOGGER.0,
-                "get_cpus(); could not read /sys/devices/system/cpu/online; error: {:?}", e
-            );
-            OxidebpfError::FileIOError
-        },
-    )?)
-    .map_err(|e| {
-        info!(
-            LOGGER.0,
-            "get_cpus(); utf8 string conversion error while getting cpus; error: {:?}", e
-        );
-        OxidebpfError::Utf8StringConversionError
-    })?;
-    process_cpu_string(cpu_string)
 }
 
 pub(crate) enum PerfEvent {
@@ -333,7 +264,7 @@ impl PerfMap {
         let mmap_size = page_size * (page_count + 1);
 
         let mut loaded_perfmaps = Vec::<PerfMap>::new();
-        for cpuid in get_cpus()?.iter() {
+        for cpuid in cpu_info::online()?.iter() {
             let fd: RawFd = crate::perf::syscall::perf_event_open(&event_attr, -1, *cpuid, -1, 0)?;
             let base_ptr: *mut _;
             base_ptr = unsafe {


### PR DESCRIPTION
This PR adds a fix to the default number of cpus when setting the `max_entries` field on the perfmap. The issue being addressed is an edge case when the number of cpus changes due to a hot swap of cpus on a system. The proposed fix is to set the `max_entries` value based on the max possible cpu count instead of currently online cpu count.