### PR TITLE
Update deps + perfmap refactors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,10 @@ mio = { version = "0.8", features = ["os-poll", "os-ext"] }
 retry = "1.3.0"
 proc-mounts = "0.2.4"
 slog = "2.7.0"
-slog-stdlog = "4.1.0"
-slog-term = "2.8.0"
 slog-atomic = "3.1.0"
 thread-priority = "0.7.0"
 
 [dev-dependencies]
-oxidebpf = { path = ".", features = ["log_buf"] }
 memmap = "0.7.0"
 scopeguard = "1.1.0"
 ctrlc = "3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,19 +21,19 @@ edition = "2021"
 [dependencies]
 libc = "0.2.105"
 goblin = "0.4.3"
-nix = "0.22.2"
+nix = "0.23.1"
 itertools = "0.10.1"
 crossbeam-channel = "0.5.1"
 lazy_static = "1.4.0"
 uuid = { version = "0.8.2", features = ["v4"] }
-mio = { version = "0.7.14", features = ["os-poll", "os-ext"] }
+mio = { version = "0.8", features = ["os-poll", "os-ext"] }
 retry = "1.3.0"
 proc-mounts = "0.2.4"
 slog = "2.7.0"
 slog-stdlog = "4.1.0"
 slog-term = "2.8.0"
 slog-atomic = "3.1.0"
-thread-priority = "0.3.0"
+thread-priority = "0.7.0"
 
 [dev-dependencies]
 oxidebpf = { path = ".", features = ["log_buf"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,7 @@ pub enum OxidebpfError {
     /// There's a chance we need to change the path name and retry, which is what
     /// this error indicates.
     KretprobeNamingError,
+    UnknownPerfEvent(u32),
 }
 
 impl Display for OxidebpfError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,11 +200,19 @@ impl From<SchedulingPolicy> for thread_priority::ThreadPriority {
     fn from(policy: SchedulingPolicy) -> Self {
         match policy {
             SchedulingPolicy::Other(_) | SchedulingPolicy::Idle | SchedulingPolicy::Batch(_) => {
-                thread_priority::ThreadPriority::Specific(0)
+                thread_priority::ThreadPriority::Crossplatform(
+                    (0_u8)
+                        .try_into()
+                        .expect("bug: hardcoded priority value not accepted by thread_policy"),
+                )
             }
             SchedulingPolicy::FIFO(polling_priority) | SchedulingPolicy::RR(polling_priority) => {
-                // this crate only accepts priorities 1-99 inclusive, so bump up a 0 to 1
-                thread_priority::ThreadPriority::Specific(polling_priority.clamp(1, 99) as u32)
+                thread_priority::ThreadPriority::Crossplatform(
+                    polling_priority
+                        .clamp(0_u8, 99_u8)
+                        .try_into()
+                        .expect("bug: clamped priority value not accepted by thread_policy"),
+                )
             }
             SchedulingPolicy::Deadline(r, d, p) => {
                 thread_priority::ThreadPriority::Deadline(r, d, p)

--- a/src/maps/mod.rs
+++ b/src/maps/mod.rs
@@ -285,7 +285,7 @@ struct PerfEventIterator<'a> {
     data_tail: u64,
     data_head: u64,
     errored: bool,
-    copy_buf: Vec<u8>, // re-usable buffer to make ring joints be contigous
+    copy_buf: Vec<u8>, // re-usable buffer to make ring joins be contiguous
 
     // calculated at creation
     mmap_size: usize,
@@ -363,8 +363,8 @@ impl<'a> Iterator for PerfEventIterator<'a> {
             // only update the internal tail for now. We will update
             // the actual tail when dropping the iterator. It would be
             // safe to update the tail now though since the data is
-            // coped. We could consider modifying the tail sooner if
-            // we aren't sending events fast enough in the ftuure.
+            // copied. We could consider modifying the tail sooner if
+            // we aren't sending events fast enough in the future.
             self.data_tail += event_size as u64;
 
             if event.is_err() {
@@ -882,7 +882,7 @@ fn page_size() -> Result<usize, OxidebpfError> {
 /// if it failed to close it.
 ///
 /// # Safety:
-/// The fd has be a valid from a perf_event_open syscall
+/// The fd must be valid and come from a perf_event_open syscall
 unsafe fn create_raw_perf(fd: RawFd, mmap_size: usize) -> Result<*mut PerfMem, OxidebpfError> {
     let base_ptr = libc::mmap(
         null_mut(),

--- a/src/maps/perf_map_poller.rs
+++ b/src/maps/perf_map_poller.rs
@@ -88,9 +88,15 @@ impl PerfMapPoller {
                 let name = &perfmap.name;
                 let cpuid = perfmap.cpuid() as i32;
 
-                perfmap
-                    .read_all()
-                    .map(move |e| e.map(|e| (name.clone(), cpuid, e)))
+                // SAFETY: events should be 0 or 1 per token->buffer
+                // meaning that no perfbuffer is running read_all more
+                // than once hence meeting the safety requirements of
+                // `read_all`
+                unsafe {
+                    perfmap
+                        .read_all()
+                        .map(move |e| e.map(|e| (name.clone(), cpuid, e)))
+                }
             })
             .filter_map(|e| match e {
                 Ok(e) => Some(e),

--- a/src/maps/perf_map_poller.rs
+++ b/src/maps/perf_map_poller.rs
@@ -101,8 +101,8 @@ impl PerfMapPoller {
             });
 
         let mut dropped = 0;
-        for event in perf_events {
-            match event.2 {
+        for (map_name, cpuid, event) in perf_events {
+            match event {
                 PerfEvent::Lost(count) => {
                     dropped += count;
                     // it's okay if the channel is full try again
@@ -114,11 +114,11 @@ impl PerfMapPoller {
                         Err(TrySendError::Full(_)) => {}
                     }
                 }
-                PerfEvent::Sample(e) => tx
+                PerfEvent::Sample(data) => tx
                     .send(PerfChannelMessage::Event {
-                        map_name: event.0,
-                        cpuid: event.1,
-                        data: e.data,
+                        map_name,
+                        cpuid,
+                        data,
                     })
                     .map_err(|_| RunError::Disconnected)?,
             };

--- a/src/perf/syscall.rs
+++ b/src/perf/syscall.rs
@@ -203,8 +203,7 @@ pub(crate) fn perf_event_open(
     group_fd: RawFd, // SAFETY: this is only ever called with `group_id = -1`
     flags: c_ulong,
 ) -> Result<RawFd, OxidebpfError> {
-    #![allow(clippy::useless_conversion)] // fails to compile otherwise
-    if !((*PERF_PATH).as_path().exists()) {
+    if !((*PERF_PATH).exists()) {
         info!(LOGGER.0, "perf_event_open(); PERF_PATH does not exist");
         return Err(OxidebpfError::PerfEventDoesNotExist);
     }
@@ -269,14 +268,12 @@ pub(crate) fn perf_event_ioc_set_bpf(perf_fd: RawFd, data: u32) -> Result<i32, O
 
 /// Safe wrapper around `u_perf_event_ioc_enable()`
 pub(crate) fn perf_event_ioc_enable(perf_fd: RawFd) -> Result<i32, OxidebpfError> {
-    #![allow(clippy::redundant_closure)]
-    unsafe { u_perf_event_ioc_enable(perf_fd).map_err(|e| OxidebpfError::PerfIoctlError(e)) }
+    unsafe { u_perf_event_ioc_enable(perf_fd).map_err(OxidebpfError::PerfIoctlError) }
 }
 
 /// Safe wrapper around `u_perf_event_ioc_disable()`
 pub(crate) fn perf_event_ioc_disable(perf_fd: RawFd) -> Result<i32, OxidebpfError> {
-    #![allow(clippy::redundant_closure)]
-    unsafe { u_perf_event_ioc_disable(perf_fd).map_err(|e| OxidebpfError::PerfIoctlError(e)) }
+    unsafe { u_perf_event_ioc_disable(perf_fd).map_err(OxidebpfError::PerfIoctlError) }
 }
 
 fn perf_attach_tracepoint_with_debugfs(


### PR DESCRIPTION
This was originally going to be PR to add the metrics crate but during my refactors to understand the code further I realized it grew too big so now this is only a refactor PR. I will submit a follow-up PR pretty soon with the actual metrics crate changes. 

* removed a couple of clippy ignores and instead just made the code obey clippy
* Removed the need to to read/write to the mmap header/tail for every event. Instead just read/write it once per `epoll`. Also added an extra `fence` per the docs. 
* Adds an extra error variant to the enum. This is *okay* because the enum is marked as `non_exhaustive`. 