### PR TITLE
Bump metrics to 0.20.1, remove metrics-macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,7 @@ proc-mounts = "0.2.4"
 slog = "2.7.0"
 slog-atomic = "3.1.0"
 thread-priority = "0.7.0"
-metrics = { version = "0.18.1", optional = true }
-metrics-macros = { version = "0.5.1", optional = true }
+metrics = { version = "0.20.1", optional = true }
 
 [dev-dependencies]
 memmap = "0.7.0"


### PR DESCRIPTION
Bump metrics dependency and remove metrics-macros as is already a dependency of metrics.

Resolves an issue where metrics may not appear due to version mismatch.