### PR TITLE
[TOOL-1239] Update CircleCI deprecated image tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
 jobs:
   verify-purity:
     machine:
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2004:current
     resource_class: medium
     environment:
       TZ: "/usr/share/zoneinfo/America/Denver"
@@ -46,7 +46,7 @@ jobs:
             cargo clippy
   build-and-test:
     machine:
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2004:current
     resource_class: medium
     environment:
       TZ: "/usr/share/zoneinfo/America/Denver"


### PR DESCRIPTION
This PR is opened by an automated tool, run by the PIE team, that is designed to help bulk update deprecated image tags for CircleCI images.